### PR TITLE
Simplified AsyncRAT-Sharp.csproj

### DIFF
--- a/AsyncRAT-C#/AsyncRAT-Sharp/AsyncRAT-Sharp.csproj
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/AsyncRAT-Sharp.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\Binarys\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Moved the output path to a folder (/Binarys) in the root directory of the project removing the need for the Server to move the stub into its own directory