### PR TITLE
Added discard to PortsFrm_Load's Methods.FadeIn

### DIFF
--- a/AsyncRAT-C#/AsyncRAT-Sharp/Forms/FormPorts.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Forms/FormPorts.cs
@@ -18,7 +18,7 @@ namespace AsyncRAT_Sharp.Forms
 
         private void PortsFrm_Load(object sender, EventArgs e)
         {
-            Methods.FadeIn(this, 5);
+            _ = Methods.FadeIn(this, 5);
 
             if (Properties.Settings.Default.Ports.Length == 0)
             {


### PR DESCRIPTION
Added discard to PortsFrm_Load's Methods.FadeIn to suppress and solve CS4014
Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.