### PR TITLE
Possible fix for performance issues for WinForms

### DIFF
--- a/AsyncRAT-C#/AsyncRAT-Sharp/Program.cs
+++ b/AsyncRAT-C#/AsyncRAT-Sharp/Program.cs
@@ -26,6 +26,9 @@ namespace AsyncRAT_Sharp
         [STAThread]
         static void Main()
         {
+            Process Self = Process.GetCurrentProcess();
+            Self.PriorityClass = ProcessPriorityClass.RealTime; //Warning! Dont RealTime & Marshel
+
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             form1 = new Form1();


### PR DESCRIPTION
Set the process priority to RealTime assigning it priority over others, while i wouldn't usually suggest this as this is a "single" Async threaded program it would be advisable in this case